### PR TITLE
[Left Click Dropper] Allow item list to be split by newlines

### DIFF
--- a/src/main/java/com/zom/leftclickdrop/MenuSwapperPlugin.java
+++ b/src/main/java/com/zom/leftclickdrop/MenuSwapperPlugin.java
@@ -25,6 +25,7 @@
 
 package com.zom.leftclickdrop;
 
+import com.google.common.base.Splitter;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.inject.Provides;
 import java.util.HashSet;
@@ -62,6 +63,11 @@ public class MenuSwapperPlugin extends Plugin
 	private List<String> itemList;
 
 	private HashSet<String> releaseItems;
+
+	private Splitter CONFIG_SPLITTER = Splitter
+			.onPattern("([,\n])")
+			.omitEmptyStrings()
+			.trimResults();
 
 	@Subscribe
 	public void onClientTick(ClientTick clientTick)
@@ -195,7 +201,7 @@ public class MenuSwapperPlugin extends Plugin
 	{
 		if (event.getGroup().equals("leftclickdrop"))
 		{
-			itemList = Text.fromCSV(config.itemList().toLowerCase());
+			itemList = CONFIG_SPLITTER.splitToList(config.itemList().toLowerCase());
 		}
 	}
 }


### PR DESCRIPTION
Finally opening a PR to address what I wish we had for #2. This PR just uses a custom splitter, same thing that powers Text.fromCSV, to allow us to use either `,` or `\n`.
